### PR TITLE
Add ratelimiting to the /login and /signup endpoints

### DIFF
--- a/owdex/__init__.py
+++ b/owdex/__init__.py
@@ -27,10 +27,10 @@ def create_app(config_dict=None):
         app.config = app.config | config_dict
 
     app.um = UserManager(
-        app.config["ADMIN_USERNAME"],
-        app.config["ADMIN_PASSWORD"],
         app.config["MONGO_HOST"],
-        app.config["MONGO_PORT"]
+        app.config["MONGO_PORT"],
+        app.config["ADMIN_USERNAME"],
+        app.config["ADMIN_PASSWORD"]
     )
 
     app.lm = LinkManager(

--- a/owdex/__init__.py
+++ b/owdex/__init__.py
@@ -42,7 +42,7 @@ def create_app(config_dict=None):
     app.limiter = Limiter(
         get_remote_address,
         app = app,
-        storage_uri = f'mongodb://{app.config["MONGO_HOST"]}:{app.config["MONGO_PORT"]}',
+        storage_uri = app.um.mongo_uri,
         strategy = "fixed-window-elastic-expiry"
     )
 

--- a/owdex/__init__.py
+++ b/owdex/__init__.py
@@ -11,6 +11,7 @@ from .search import search_bp
 from .add import add_bp
 from .users import users_bp
 from .vote import vote_bp
+from .limiter import limiter
 
 
 def create_app(config_dict=None):
@@ -41,6 +42,12 @@ def create_app(config_dict=None):
             "archive"
         ]
         )
+
+    app.config[
+        "RATELIMIT_STORAGE_URI"
+    ] = f'mongodb://{app.config["MONGO_HOST"]}:{app.config["MONGO_PORT"]}'
+    app.config["RATELIMIT_STRATEGY"] = "fixed-window-elastic-expiry"
+    limiter.init_app(app)
 
     with app.app_context():
         app.register_blueprint(page_bp)

--- a/owdex/limiter.py
+++ b/owdex/limiter.py
@@ -1,0 +1,6 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# TODO check if remote address is good enough as key
+# TODO decide if headers should be enabled
+limiter = Limiter(key_func=get_remote_address, headers_enabled=True)

--- a/owdex/limiter.py
+++ b/owdex/limiter.py
@@ -1,6 +1,0 @@
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
-
-# TODO check if remote address is good enough as key
-# TODO decide if headers should be enabled
-limiter = Limiter(key_func=get_remote_address, headers_enabled=True)

--- a/owdex/requirements.txt
+++ b/owdex/requirements.txt
@@ -1,3 +1,4 @@
+-i https://pypi.org/simple
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
 attrs==22.2.0
@@ -8,27 +9,39 @@ cffi==1.15.1
 charset-normalizer==3.1.0
 click==8.1.3
 coverage==7.2.1
+deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 dnspython==2.3.0
 exceptiongroup==1.1.0
-Flask==2.2.3
+flask==2.2.3
+flask-limiter==3.3.0
 idna==3.4
+importlib-resources==5.12.0 ; python_version >= '3.7'
 iniconfig==2.0.0
 itsdangerous==2.1.2
-Jinja2==3.1.2
-MarkupSafe==2.1.2
+jinja2==3.1.2
+limits==3.3.1 ; python_version >= '3.7'
+markdown-it-py==2.2.0 ; python_version >= '3.7'
+markupsafe==2.1.2
+mdurl==0.1.2 ; python_version >= '3.7'
+ordered-set==4.1.0 ; python_version >= '3.7'
 packaging==23.0
 pluggy==1.0.0
 pycparser==2.21
+pygments==2.14.0 ; python_version >= '3.6'
 pymongo==4.3.3
 pysolr==3.9.0
 pytest==7.2.2
 python-dotenv==1.0.0
 requests==2.28.2
+rich==13.3.3 ; python_full_version >= '3.7.0'
+setuptools==67.6.1 ; python_version >= '3.7'
 six==1.16.0
 soupsieve==2.4
 toml==0.10.2
 tomli==2.0.1
+typing-extensions==4.5.0 ; python_version >= '3.7'
 url-normalize==1.4.3
 urllib3==1.26.14
 waitress==2.1.2
-Werkzeug==2.2.3
+werkzeug==2.2.3
+wrapt==1.15.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/owdex/usermanager.py
+++ b/owdex/usermanager.py
@@ -19,7 +19,8 @@ class UserManager():
             admin_username (str): The username for the admin user.
             admin_password (str): The password for the admin user.
         """
-        self._mongo = MongoClient(f"mongodb://{host}:{port}/")
+        self.mongo_uri = f"mongodb://{host}:{port}/"
+        self._mongo = MongoClient(self.mongo_uri)
         self._table = self._mongo["users"]["users"]
         self._hasher = PasswordHasher()
 

--- a/owdex/users.py
+++ b/owdex/users.py
@@ -3,11 +3,17 @@ from flask import current_app as app
 from argon2.exceptions import VerifyMismatchError
 
 from .usermanager import require_login
+from .limiter import limiter
 
 users_bp = f.Blueprint("users", __name__, template_folder="templates")
 
 
 @users_bp.route("/login", methods=["GET", "POST"])
+@limiter.limit(
+    "5/minute;10/hour;25/day",
+    scope="users",
+    deduct_when=lambda response: response.status_code != 200,
+)
 def login():
     success = None
 
@@ -31,6 +37,10 @@ def login():
 
 
 @users_bp.route("/signup", methods=["GET", "POST"])
+@limiter.limit(
+    "5/minute;10/hour;25/day",
+    scope="users",
+)
 def signup():
     success = None
 

--- a/owdex/users.py
+++ b/owdex/users.py
@@ -14,7 +14,7 @@ users_bp = f.Blueprint("users", __name__, template_folder="templates")
     deduct_when=lambda response: response.status_code != 200,
 )
 def login():
-    success = None
+    status = None
 
     if f.request.method == "POST":
         username = f.request.form["username"]
@@ -23,16 +23,16 @@ def login():
             app.um.verify(username, password)
         except VerifyMismatchError:
             # wrong password
-            success = False
+            status = 401
         except KeyError:
             # no such username
-            success = False
+            status = 401
         else:
             # login successful
             f.session["user"] = username
-            success = True
+            status = 200
 
-    return f.render_template("login.html", success=success)
+    return f.render_template("login.html"), status
 
 
 @users_bp.route("/signup", methods=["GET", "POST"])
@@ -41,16 +41,19 @@ def login():
     scope="users",
 )
 def signup():
-    success = None
+    status = None
 
     if f.request.method == "POST":
         try:
             app.um.create(f.request.form["username"],
                           f.request.form["password"])
         except KeyError:
-            success = False
+            # username already exists
+            status = 409
+        else:
+            status = 200
 
-    return f.render_template("signup.html", success=success)
+    return f.render_template("signup.html"), status
 
 
 @users_bp.route("/logout")

--- a/owdex/users.py
+++ b/owdex/users.py
@@ -3,13 +3,12 @@ from flask import current_app as app
 from argon2.exceptions import VerifyMismatchError
 
 from .usermanager import require_login
-from .limiter import limiter
 
 users_bp = f.Blueprint("users", __name__, template_folder="templates")
 
 
 @users_bp.route("/login", methods=["GET", "POST"])
-@limiter.limit(
+@app.limiter.limit(
     "5/minute;10/hour;25/day",
     scope="users",
     deduct_when=lambda response: response.status_code != 200,
@@ -37,7 +36,7 @@ def login():
 
 
 @users_bp.route("/signup", methods=["GET", "POST"])
-@limiter.limit(
+@app.limiter.limit(
     "5/minute;10/hour;25/day",
     scope="users",
 )


### PR DESCRIPTION
See also #27 

**Describe the fix**

This is using the flask-limiter add-on.
Limits and respective windows are stored in MongoDB.

**Additional context**

This is currently set up rather restrictive.
Successful logins don't count towards the limit.
It generates `X-Ratelimit-*` headers, we need to think if we want that.
