### PR TITLE
Make the login error messages generic

### DIFF
--- a/owdex/users.py
+++ b/owdex/users.py
@@ -23,9 +23,11 @@ def login():
         try:
             app.um.verify(username, password)
         except VerifyMismatchError:
-            return error(HTTPStatus.UNAUTHORIZED, explanation=f"Wrong password for username {username}!")
+            return error(HTTPStatus.UNAUTHORIZED,
+                         explanation="Wrong username or password")
         except KeyError:
-            return error(HTTPStatus.UNAUTHORIZED, explanation="No such username!")
+            return error(HTTPStatus.UNAUTHORIZED,
+                         explanation="Wrong username or password")
         else:
             f.session["user"] = username
     return f.render_template("login.html")


### PR DESCRIPTION
It is common bad practice to have distinct error messages, as this  may simplify the work needed for an attacker to guess valid usernames or passwords.

This just changes the error message to be the same for both the `User does not exist` and the `Password is wrong` cases to be the same
